### PR TITLE
bump to 0.13.3 and fix maxbuffer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,16 @@
+## Datadog modifications
+
+v0.13.3
+* Increase maxBuffer size that crashes the program when doing large KVS updates.
+
+v0.13.2
+* Patch initial `path_whitelist` implementation to fix edge cases.
+
+v0.13.1
+* Add `path_whitelist` option to repos that allows only loading in the KVS values matching a certain path.
+
+## Upstream
+
 v0.12.14 (UNRELEASED)
 * Use --config-key as the option flag. --config_key still exists for backwards compatibility [GH-141]
 * Only ignore embedded JSON/YAML/properties file extensions [GH-123]

--- a/lib/git/commands.js
+++ b/lib/git/commands.js
@@ -9,7 +9,7 @@ var logger = require('../logging.js');
  */
 var run_command = function(cmd, cwd, cb) {
   logger.trace('Running %s in %s', cmd, cwd);
-  var child = exec(cmd, {cwd: cwd}, function(err, stdout, stderr) {
+  var child = exec(cmd, {cwd: cwd, maxBuffer: 5 * 1024 * 1024}, function(err, stdout, stderr) {
     if (stdout) stdout = stdout.trim();
     if (stderr) stderr = stderr.trim();
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "git2consul",
   "description": "System for moving data from git to consul",
   "license": "Apache-2.0",
-  "version": "0.13.2",
+  "version": "0.13.3",
   "contributors": [
     {
       "name": "Ryan Breen",


### PR DESCRIPTION
Bump it to 5 MB. The default is 200k which is really small for us.

```
➜  consul-config git:(master) ✗ git ls-tree -r HEAD | wc -c
  508012