### PR TITLE
Use spawnSync to avoid hitting buffer limits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Datadog modifications
 
+v0.13.4
+* Switch to spawnSync to avoid buffer limits.
+
 v0.13.3
 * Increase maxBuffer size that crashes the program when doing large KVS updates.
 

--- a/lib/git/commands.js
+++ b/lib/git/commands.js
@@ -1,4 +1,4 @@
-var exec = require('child_process').exec;
+var spawnSync = require('child_process').spawnSync;
 
 var logger = require('../logging.js');
 
@@ -9,19 +9,22 @@ var logger = require('../logging.js');
  */
 var run_command = function(cmd, cwd, cb) {
   logger.trace('Running %s in %s', cmd, cwd);
-  var child = exec(cmd, {cwd: cwd, maxBuffer: 5 * 1024 * 1024}, function(err, stdout, stderr) {
-    if (stdout) stdout = stdout.trim();
-    if (stderr) stderr = stderr.trim();
+  var output = spawnSync(cmd, { cwd: cwd, shell: true });
+  if (output.error || output.status != 0) {
+    return cb(new Error(output.error + ' ' + output.stderr))
+  }
 
-    if (stdout.length > 0) logger.trace("stdout:\n" + stdout);
-    if (stderr.length > 0) logger.trace("stderr:\n" + stderr);
+  var stdour = '', stderr = '';
+  if (output.stdout) {
+    stdout = output.stdout.toString().trim();
+  }
+  if (output.stderr) {
+     stderr = output.stderr.toString().trim();
+  }
 
-    if (err) {
-      return cb(new Error(err + ' ' + stderr));
-    }
-
-    cb(null, stdout);
-  });
+  if (stdout.length > 0) logger.trace('stdout:\n' + stdout);
+  if (stderr.length > 0) logger.trace('stderr:\n' + stderr);
+  cb(null, stdout);
 };
 
 exports.init = function(cwd, cb) {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "git2consul",
   "description": "System for moving data from git to consul",
   "license": "Apache-2.0",
-  "version": "0.13.3",
+  "version": "0.13.4",
   "contributors": [
     {
       "name": "Ryan Breen",


### PR DESCRIPTION
process `spawn` will read data into a stream as soon as it starts executing. This should help us avoid having to keep bumping up the buffer limit which we have hit again.

For more details see: http://www.hacksparrow.com/difference-between-spawn-and-exec-of-node-js-child_process.html

cc @LeoCavaille 