### PR TITLE
Move heartbeat after ref change

### DIFF
--- a/lib/git/branch.js
+++ b/lib/git/branch.js
@@ -115,6 +115,7 @@ Branch.prototype.timedHandleRefChange = function(target_ref, cb) {
   delta = (end[0] * 1000) + (end[1] / 1000000);
   logger.debug('Branch.prototype.handleRefChange execution time (hr): %dms', delta);
   dogstatsd.timing('git2consul.timing', delta, ['git:update']);
+  global.last_heartbeat_time = process.hrtime();
   dogstatsd.gauge('git2consul.heartbeat', 1);
 }
 

--- a/lib/git/branch.js
+++ b/lib/git/branch.js
@@ -115,6 +115,7 @@ Branch.prototype.timedHandleRefChange = function(target_ref, cb) {
   delta = (end[0] * 1000) + (end[1] / 1000000);
   logger.debug('Branch.prototype.handleRefChange execution time (hr): %dms', delta);
   dogstatsd.timing('git2consul.timing', delta, ['git:update']);
+  dogstatsd.gauge('git2consul.heartbeat', 1);
 }
 
 Branch.prototype.handleRefChange = function(target_ref, cb) {

--- a/lib/git/hooks/polling.js
+++ b/lib/git/hooks/polling.js
@@ -22,7 +22,6 @@ exports.init = function(config, repo) {
     logger.trace('Polling branch %s of repo %s', branch.name, repo.name);
     setInterval(function() {
       logger.debug('Service heartbeat: Polling branch %s of repo %s', branch.name, repo.name);
-      dogstatsd.gauge('git2consul.heartbeat', 1);
       branch.timedHandleRefChange(null, function(err) {
         /* istanbul ignore next */
         if (err) logger.error(err);

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,4 +1,5 @@
 var logger = require('./logging.js');
+var liveness = require('./liveness.js');
 
 var fs = require('fs');
 var os = require('os');
@@ -13,6 +14,7 @@ global.secure = process.env.CONSUL_SECURE || false;
 global.token = process.env.TOKEN || null;
 global.config_file = null;
 global.config_key = "git2consul/config"
+global.liveness_threshold = 60;
 
 /**
  * Parse out flags and override defaults if they are set
@@ -36,6 +38,15 @@ for (var i=2; i<process.argv.length; ++i) {
     }
     global.config_key = process.argv[i+1];
   }
+
+  if(process.argv[i] === '--liveness-threshold') {
+    if(i+1 >= process.argv.length) {
+      logger.error("No value provided with --liveness-threshold option");
+      process.exit(4);
+    }
+    global.liveness_threshold = process.argv[i+1];
+  }
+
 
   if(process.argv[i] === '-p' || process.argv[i] === '--port') {
     if(i+1 >= process.argv.length) {
@@ -119,6 +130,9 @@ var read_config = function(){
     process.on('uncaughtException', function(err) {
       logger.error("Uncaught exception " + err);
     });
+
+    // Set up liveness probe
+    liveness.init()
 
     // Set up git for each repo
     git.timedCreateRepos(config, function(err) {

--- a/lib/liveness.js
+++ b/lib/liveness.js
@@ -20,5 +20,5 @@ module.exports.init = function() {
   });
 
   app.listen(PORT, HOST);
-  logger.info("Running on http://%s:%d", HOST, PORT);
+  logger.info("Running health check service on http://%s:%d", HOST, PORT);
 }

--- a/lib/liveness.js
+++ b/lib/liveness.js
@@ -1,0 +1,24 @@
+'use strict';
+var express = require('express');
+var logger = require('./logging.js');
+var util = require('util')
+
+module.exports.init = function() {
+  const PORT = 8080;
+  const HOST = '0.0.0.0';
+  const app = express();
+
+  app.get('/liveness',(req,res)=> {
+      var delta = process.hrtime(global.last_heartbeat_time);
+      var delta_seconds = delta[0]
+      if (delta_seconds < global.liveness_threshold ) {
+          res.send ("Health check passed");
+      } else {
+          var message = util.format("Health check did not pass, %d seconds since last heartbeat", delta_seconds)
+          res.status(500).send(message);
+      }
+  });
+
+  app.listen(PORT, HOST);
+  logger.info("Running on http://%s:%d", HOST, PORT);
+}

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "git2consul",
   "description": "System for moving data from git to consul",
   "license": "Apache-2.0",
-  "version": "0.13.6",
+  "version": "0.13.7",
   "contributors": [
     {
       "name": "Ryan Breen",


### PR DESCRIPTION
Only send heartbeat if we're effectively checking branch ref changes.
We had an issue where the heartbeat was send while the polling stopped. 